### PR TITLE
Some updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A variable length encoding for unsigned 64 bit integers."
 repository = "https://github.com/AljoschaMeyer/varu64-rs"
 readme = "README.md"
 license = "AGPL-3.0"
+edition = "2018"
 
 [dependencies]
 snafu = {version = "0.6.10", default-features=false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/AljoschaMeyer/varu64-rs"
 readme = "README.md"
 license = "AGPL-3.0"
 
+[dependencies]
+snafu = {version = "0.6.10", default-features=false}
+
 [dev-dependencies]
 quickcheck = "0.7.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,6 @@
 //! Implementation of the [varu64 format](https://github.com/AljoschaMeyer/varu64-rs) in rust.
 #![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
 
-extern crate core;
-extern crate snafu;
 use core::convert::TryFrom;
 use core::num::NonZeroU64;
 use snafu::{OptionExt, Snafu};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,16 +34,25 @@ pub fn encoding_length(n: u64) -> usize {
     }
 }
 
+/// Return how many bytes the encoding of `n: NonZeroU64` will take up.
+pub fn encoding_length_non_zero_u64(n: NonZeroU64) -> usize {
+    encoding_length_gt_x(u64::from(n), 0)
+}
+
+fn encoding_length_gt_x(n: u64, x: u64) -> usize {
+    encoding_length(u64::from(n) - 1 - x)
+}
+
 /// Encodes `n: NonZeroU64` into the output buffer, returning how many bytes have been written.
 ///
 /// # Panics
 /// Panics if the buffer is not large enough to hold the encoding.
 pub fn encode_non_zero_u64(n: NonZeroU64, out: &mut [u8]) -> usize {
-    encode_gt_x(n.into(), 1, out)
+    encode_gt_x(n.into(), 0, out)
 }
 
 fn encode_gt_x(n: u64, x: u64, out: &mut [u8]) -> usize {
-    encode(n - x, out)
+    encode(n - 1 - x, out)
 }
 
 /// Decode a `NonZeroU64` from the `input` buffer, returning the number and the remaining bytes.
@@ -57,14 +66,14 @@ fn encode_gt_x(n: u64, x: u64, out: &mut [u8]) -> usize {
 /// a `NonCanonical` error (even if the partial input could already be detected to be
 /// noncanonical).
 pub fn decode_non_zero_u64(input: &[u8]) -> Result<(NonZeroU64, &[u8]), (DecodeError, &[u8])> {
-    decode_gt_x(input, 1).and_then(|(n, buff)| match NonZeroU64::try_from(n) {
+    decode_gt_x(input, 0).and_then(|(n, buff)| match NonZeroU64::try_from(n) {
         Ok(num) => Ok((num, buff)),
         Err(_) => Err((DecodeError::ExpectedANonZeroU64, buff)),
     })
 }
 
 fn decode_gt_x(input: &[u8], x: u64) -> Result<(u64, &[u8]), (DecodeError, &[u8])> {
-    decode(input).map(|(n, buff)| (n + x, buff))
+    decode(input).map(|(n, buff)| (n + x + 1, buff))
 }
 
 /// Encodes `n` into the output buffer, returning how many bytes have been written.

--- a/src/nb.rs
+++ b/src/nb.rs
@@ -423,6 +423,8 @@ impl<T: AsRef<[u8]>> LengthValueEncoder<T> {
 
 #[cfg(test)]
 mod tests {
+    use quickcheck::quickcheck;
+
     use super::super::*;
 
     fn decode_all(


### PR DESCRIPTION
- Update rust edition to 2018
- Use Snafu for errors (this was annoying me when using varu64 because `DecodeError` didn't implement `Display` with `no_std`.
- Add encode / decode for NonZeroU64